### PR TITLE
bug fix: Can't call method "get_text" while saving the file  

### DIFF
--- a/lib/Caecilia.pm
+++ b/lib/Caecilia.pm
@@ -194,7 +194,11 @@ sub save_as_cb {
 	}
 
 	# connect the dialog to the callback function save_response_cb
-	$save_dialog->signal_connect("response" => \&save_response_cb, [$editor,$filename_ref]);
+	#$save_dialog->signal_connect("response" => \&save_response_cb, [$editor,$filename_ref]);
+
+        $save_dialog->signal_connect("response" => sub {
+            return save_response_cb(shift, shift, $editor, $filename_ref);
+        });
 
 	# show the dialog
 	$save_dialog->show();
@@ -203,9 +207,7 @@ sub save_as_cb {
 # Callback Function for the response of the save-as and save dialog 
 # (= saving the file!)
 sub save_response_cb {
-	my ($dialog, $response_id, $args) = @_;
-	my $editor = $args->[0];
-	my $filename_ref = $args->[1];
+	my ($dialog, $response_id, $editor, $filename_ref ) = @_;
 	
 	# if response id is "ACCEPTED" (the button "Open" has been clicked)
 	if ($response_id eq "accept") {


### PR DESCRIPTION
Hi,

 I was getting the following error  while saving the file. 

Can't call method "get_text" on an undefined value at /usr/local/share/perl/5.18.2/Caecilia.pm line 215.

 This PR would fix this issue.